### PR TITLE
Update PPOCR-README.md

### DIFF
--- a/examples/PPOCR/PPOCR-Rec/README.md
+++ b/examples/PPOCR/PPOCR-Rec/README.md
@@ -46,6 +46,14 @@ cd model
 ./download_model.sh
 ```
 
+After download onnx model file, should seting fix input shape. If you not install paddle2onnx, install it first.
+```
+python -m paddle2onnx.optimize --input_model model/ch_PP-OCRv4_rec_infer/model.onnx \
+                               --output_model model/ch_PP-OCRv4_rec_infer/ppocrv4_rec.onnx \
+                               --input_shape_dict "{'x':[1,3,48,320]}"
+```
+
+
 **(Optional)PADDLE to ONNX**: Please refer [Paddle_2_ONNX.md](Paddle_2_ONNX.md) 
 
 


### PR DESCRIPTION
add necessary step when use onnx model file with the download link

this pretrain model onnx can not use to convert to rknn file， if we just do convert and load rknn file，we can get the right result。
this pretrain model onnx should seting fix input shape before convert to rknn
i think this step have to point out, or we should change the download link ,replaced with another onnx that can be used to convert to rknn directly
![image](https://github.com/user-attachments/assets/d6834115-065c-4fa2-8a4b-79a978c4a4d7)
